### PR TITLE
Add provided elemnt to the java-lib configuration

### DIFF
--- a/duell/build/plugin/platform/PlatformBuild.hx
+++ b/duell/build/plugin/platform/PlatformBuild.hx
@@ -533,11 +533,17 @@ class PlatformBuild
 
             TemplateHelper.recursiveCopyTemplatedFiles(javaLib.PATH, Path.join([projectDirectory, "deps", javaLib.NAME]), Configuration.getData(), Configuration.getData().TEMPLATE_FUNCTIONS);
 
+            /// Make sure the libs folder is there
+            var libsDirectoryPath: String = Path.join([projectDirectory, "deps", javaLib.NAME, "libs"]);
+            if(!FileSystem.exists(libsDirectoryPath) && javaLib.PROVIDED.length > 0)
+            {
+                PathHelper.mkdir(libsDirectoryPath);
+            }
             /// Handling Provided jars
             for (providedItem  in  javaLib.PROVIDED)
             {
                 var providedSrcPath: String = Path.join([projectDirectory, "libs", providedItem]);
-                var providedDestPath: String = Path.join([projectDirectory, "deps", javaLib.NAME, "libs", providedItem]);
+                var providedDestPath: String = Path.join([libsDirectoryPath, providedItem]);
                 if(FileSystem.exists(providedSrcPath))
                 {
                     FileHelper.copyIfNewer(providedSrcPath,providedDestPath);

--- a/duell/build/plugin/platform/PlatformBuild.hx
+++ b/duell/build/plugin/platform/PlatformBuild.hx
@@ -532,6 +532,21 @@ class PlatformBuild
                 throw "Java Lib path is missing project.properties file. " + javaLib;
 
             TemplateHelper.recursiveCopyTemplatedFiles(javaLib.PATH, Path.join([projectDirectory, "deps", javaLib.NAME]), Configuration.getData(), Configuration.getData().TEMPLATE_FUNCTIONS);
+
+            /// Handling Provided jars
+            for (providedItem  in  javaLib.PROVIDED)
+            {
+                var providedSrcPath: String = Path.join([projectDirectory, "libs", providedItem]);
+                var providedDestPath: String = Path.join([projectDirectory, "deps", javaLib.NAME, "libs", providedItem]);
+                if(FileSystem.exists(providedSrcPath))
+                {
+                    FileHelper.copyIfNewer(providedSrcPath,providedDestPath);
+                }
+                else
+                {
+                    throw 'Ivalid jar path $providedItem, provided for java-lib ${javaLib.NAME}';
+                }
+            }
         }
     }
 

--- a/duell/build/plugin/platform/PlatformConfiguration.hx
+++ b/duell/build/plugin/platform/PlatformConfiguration.hx
@@ -40,7 +40,7 @@ typedef PlatformConfigurationData = {
     APP_ICON : String,
 	HXCPP_COMPILATION_ARGS : Array<String>, /// not yet used
 	ACTIVITY_EXTENSIONS : Array<String>,
-	JAVA_LIBS : Array<{ NAME : String, PATH : String }>,
+	JAVA_LIBS : Array<{ NAME : String, PATH : String, PROVIDED : Array<String>}>,
 	JAVA_SOURCES : Array<{NAME : String, PATH : String}>,
 	JARS : Array<String>,
 	FULLSCREEN : Bool,

--- a/duell/build/plugin/platform/PlatformXMLParser.hx
+++ b/duell/build/plugin/platform/PlatformXMLParser.hx
@@ -254,8 +254,12 @@ class PlatformXMLParser
 			{
 				name = element.att.name;
 			}
-
-			PlatformConfiguration.getData().JAVA_LIBS.push({PATH : path, NAME : name});
+			var provided: Array<String> = [];
+			for (providedItem in element.nodes.provided)
+			{
+				provided.push(providedItem.att.path);
+			}
+			PlatformConfiguration.getData().JAVA_LIBS.push({PATH : path, NAME : name, PROVIDED : provided});
 		}
 	}
 

--- a/schema.xsd
+++ b/schema.xsd
@@ -19,7 +19,7 @@
             <xs:element name="permission" type="d:Name"/>
             <xs:element name="raw-permission" type="d:NameLevelBothRequired"/>
             <xs:element name="activity-extension" type="d:Name"/>
-            <xs:element name="java-lib" type="d:PathNamePathRequired"/>
+            <xs:element name="java-lib" type="d:JavaLib"/>
             <xs:element name="jar" type="d:Path"/>
             <xs:element name="java-source" type="d:PathNamePathRequired"/>
             <xs:element name="supports-screen" type="d:NameValueBothRequired"/>
@@ -58,6 +58,15 @@
                 <xs:attribute name="name" type="xs:string" use="optional"/>
             </xs:extension>
         </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="JavaLib">
+        <xs:sequence maxOccurs="unbounded">
+            <xs:element name="provided" type="d:Path"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="d:Conditional" />
+        <xs:attribute name="path" type="xs:anyURI" use="required"/>
+        <xs:attribute name="name" type="xs:string" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="Drawable">


### PR DESCRIPTION
to avoid duplicate jars error while building to android I added a provided element to Java-lib configuration to tell the library that a specific jar already exist and it can use it to build
E.g:
<java-lib name="mylib-sdk" path="external/mylib">
                <provided path="myExistingJar.jar"/>
 </java-lib>
