### PR TITLE
Added dynamic test port

### DIFF
--- a/duell/build/plugin/platform/PlatformBuild.hx
+++ b/duell/build/plugin/platform/PlatformBuild.hx
@@ -850,7 +850,12 @@ class PlatformBuild
             }
         );
 
-        // TODO: Find a better/central place for the hardcoded fallback port 8181 ?
+        /**
+        * TODO: Find a better/central place for the hardcoded fallback port 8181
+        *       which is intended fall back on if the duell-tool's configuration
+        *       does not provide the TEST_PORT property (backward-compatibility).
+        *       Remove eventually...
+        **/
         var testPort:Int = untyped Configuration.getData().TEST_PORT == null ?
             8181 : Configuration.getData().TEST_PORT;
 

--- a/duell/build/plugin/platform/PlatformBuild.hx
+++ b/duell/build/plugin/platform/PlatformBuild.hx
@@ -850,8 +850,9 @@ class PlatformBuild
             }
         );
 
+        trace('!!! Android test port set to: ' + Configuration.getData().TEST_PORT + ' !!!');
         /// RUN THE LISTENER
-        TestHelper.runListenerServer(300, 8181, fullTestResultPath);
+        TestHelper.runListenerServer(300, Configuration.getData().TEST_PORT, fullTestResultPath);
 
         shutdownEmulator();
     }

--- a/duell/build/plugin/platform/PlatformBuild.hx
+++ b/duell/build/plugin/platform/PlatformBuild.hx
@@ -850,7 +850,7 @@ class PlatformBuild
             }
         );
 
-        trace('!!! Android test port set to: ' + Configuration.getData().TEST_PORT + ' !!!');
+        trace('!!!!! Set DUELLBUILDANDROID TEST_PORT to: ' + Configuration.getData().TEST_PORT + ' !!!!!');
         /// RUN THE LISTENER
         TestHelper.runListenerServer(300, Configuration.getData().TEST_PORT, fullTestResultPath);
 

--- a/duell/build/plugin/platform/PlatformBuild.hx
+++ b/duell/build/plugin/platform/PlatformBuild.hx
@@ -850,9 +850,12 @@ class PlatformBuild
             }
         );
 
-        trace('!!!!! Set DUELLBUILDANDROID TEST_PORT to: ' + Configuration.getData().TEST_PORT + ' !!!!!');
+        // TODO: Find a better/central place for the hardcoded fallback port 8181 ?
+        var testPort:Int = untyped Configuration.getData().TEST_PORT == null ?
+            8181 : Configuration.getData().TEST_PORT;
+
         /// RUN THE LISTENER
-        TestHelper.runListenerServer(300, Configuration.getData().TEST_PORT, fullTestResultPath);
+        TestHelper.runListenerServer(300, testPort, fullTestResultPath);
 
         shutdownEmulator();
     }


### PR DESCRIPTION
Hello SGF team,

in terms of making the earlier pull request for the duell-tool work I'd like you the review and add this branch to the duellbuildandroid library by chance. It would help to have two clients running on one virtual machine, both using different ports to not interfere each other.

Thanks,
Fabian
