### PR TITLE
Symbol stripping of ndk libs now optional

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -142,4 +142,10 @@
         </documentation>
     </arg>
 
+    <arg name="-stripsym" type="void">
+        <documentation>
+	        This option will strip all debugging symbols from the binaries. Example usage is when releasing to the public or to a wide audience. The unstripped libraries are still present in a libs folder on the Export for symbolication.
+        </documentation>
+    </arg>
+
 </plugin>

--- a/template/android/template/src/org/haxe/duell/DuellActivity.java
+++ b/template/android/template/src/org/haxe/duell/DuellActivity.java
@@ -32,6 +32,10 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.system.Os;
+import android.system.OsConstants;
+import android.system.ErrnoException;
+import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.Window;
@@ -92,6 +96,16 @@ public class DuellActivity extends Activity
         super.onCreate(state);
 
         requestWindowFeature(Window.FEATURE_NO_TITLE);
+
+        /// MAKE SURE WE ALWAYS HAVE CRASHLOGS
+        try
+        {
+            Os.prctl(OsConstants.PR_SET_DUMPABLE, 1, 0, 0, 0);
+        }
+        catch(ErrnoException exception)
+        {
+            Log.d("DUELL", "prctl error:" + exception.getMessage());
+        }
 
         ::if PLATFORM.FULLSCREEN::
         ::if (PLATFORM.TARGET_SDK_VERSION < 19)::


### PR DESCRIPTION
In order to properly have crash logs we need to have both a stripped and a non stripped version of the libs. The changes are:
- "-stripsym" argument for optionally stripping the symbols. This should be used for public releases only.
- "staging" folder called "libswithsym" where libs with symbols attached will be available.
- two additional steps for building:
  - copy libs from "libswithsym" folder to the final apk "libs" folder.
  - if "-stripsym" is enabled, strip the symbols on the final apk "libs" folder. 

There is also one other changed that is piggy backed here. Crash logs on some devices won't appear on the logcat unless the OS flag is set. This flag is now set on the DuellActivity, check the first commit.
