### PR TITLE
Now destroying the Application when the Main Activity is destroyed.

### DIFF
--- a/template/android/template/src/org/haxe/duell/DuellActivity.java
+++ b/template/android/template/src/org/haxe/duell/DuellActivity.java
@@ -188,6 +188,13 @@ public class DuellActivity extends Activity
 
         activity = new WeakReference<DuellActivity>(null);
         super.onDestroy();
+
+        /// Application should not exist if this activity is killed
+        /// If we do not kill the application, the static variables will
+        /// continue to live, but most importantly, the native libraries
+        /// are still loaded.
+        /// We could potentially fix this with an unload method on the native libraries.
+        System.exit(0);
     }
 
     @Override


### PR DESCRIPTION
When the Back Button is pressed, Android kills the activity but not the application. This means that the next time the user goes in, all the static variables are still alive, and the native libraries are still loaded. Since it is very difficult to properly reinitialize the native libraries, and make sure that all java code properly handles this, this is the safest solution.
