### PR TITLE
Updated versions of tools

### DIFF
--- a/duell/build/plugin/platform/PlatformBuild.hx
+++ b/duell/build/plugin/platform/PlatformBuild.hx
@@ -57,7 +57,7 @@ using StringTools;
 
 class PlatformBuild
 {
-    public var requiredSetups = [{name: "android", version: "5.0.1"}];
+    public var requiredSetups = [{name: "android", version: "5.1.0"}];
     public var supportedHostPlatforms = [LINUX, WINDOWS, MAC];
     private static inline var TEST_RESULT_FILENAME = "test_result_android.xml";
     private static inline var DEFAULT_ARMV7_EMULATOR = "duellarmv7";

--- a/duell/build/plugin/platform/PlatformConfiguration.hx
+++ b/duell/build/plugin/platform/PlatformConfiguration.hx
@@ -110,7 +110,7 @@ class PlatformConfiguration
 									  }],
 					FULLSCREEN : false,
 					TARGET_SDK_VERSION : 23,
-					BUILD_TOOLS_VERSION : "23.0.1",
+					BUILD_TOOLS_VERSION : "23.0.3",
 					INSTALL_LOCATION : "auto",
 					SUPPORTS_SCREENS : [
 									{NAME : "smallScreens", VALUE : "true"},

--- a/template/android/template/build.gradle
+++ b/template/android/template/build.gradle
@@ -4,7 +4,7 @@ buildscript {
  }
 
  dependencies {
-   classpath 'com.android.tools.build:gradle:1.2.3'
+   classpath 'com.android.tools.build:gradle:2.0.0'
  }
 }
 
@@ -36,6 +36,9 @@ android {
 		::end::
 		signingConfig signingConfigs.sign
         zipAlignEnabled true
+
+        debuggable true
+        jniDebuggable true
     }
     release {
 		::if (PLATFORM.PROGUARD_ENABLED)::

--- a/template/android/template/gradle/wrapper/gradle-wrapper.properties
+++ b/template/android/template/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jul 31 10:35:35 CEST 2015
+#Thu Apr 21 10:51:05 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
This requires that the duellsetupandroid is tagged with 5.1.0.
Also uses newer version of Gradle and enables jni debugging on -debug per manifest.
